### PR TITLE
chore: add Dockerfile for application containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY services/data_loader/ ./
+
+CMD ["uvicorn", "services.server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
This pull request adds a new `Dockerfile` to containerize the data loader service using Python 3.9. The Dockerfile sets up the working directory, installs dependencies, copies the service code, and defines the startup command for running the server.

Containerization setup:

* Added a new `Dockerfile` that uses the `python:3.9-slim` base image, sets up `/app` as the working directory, installs dependencies from `requirements.txt`, copies the `services/data_loader/` code, and starts the server with `uvicorn`.